### PR TITLE
Add data folder and use some tricks to keep the folder in the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,8 @@ dmypy.json
 cython_debug/
 
 # data science
+
+# ** makes it recursive, * matches all files
 data/**/*
 # .gitkeep is an arbitray file that enables us to keep folder structure while ignoring other files.
 !data/.gitkeep

--- a/.gitignore
+++ b/.gitignore
@@ -138,7 +138,9 @@ dmypy.json
 cython_debug/
 
 # data science
-/data
+data/**/*
+# .gitkeep is an arbitray file that enables us to keep folder structure while ignoring other files.
+!data/.gitkeep
 *.csv
 *.jpeg
 *.jpg


### PR DESCRIPTION
This PR adds the `data` folder and puts a placeholder file `.gitkeep` inside. This enables the folder structure to be maintained in the repo, preventing the need to create the folder any/every time the repo is cloned.

The `.gitignore` file is updated to ignore contents of the `data` folder but _not_ to ignore the `.gitkeep` file.
