### PR TITLE
Add pycodestyle extension to enable linting in notebooks

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,8 @@ scipy = "*"
 matplotlib = "*"
 seaborn = "*"
 jupyter = "*"
+flake8 = "*"
+pycodestyle-magic = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a915d65e9404f1372531c263576b27039da8469bc98e96f81c969aa6aa1d682a"
+            "sha256": "ea88cb0470d6f4614404f818c723af744ff98e0a96826c1ba73232e3e732d8a1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -130,6 +130,14 @@
             ],
             "markers": "python_version >= '2.7'",
             "version": "==0.3"
+        },
+        "flake8": {
+            "hashes": [
+                "sha256:15e351d19611c887e482fb960eae4d44845013cc142d42896e9862f775d8cf5c",
+                "sha256:f04b9fcbac03b0a3e58c0ab3a0ecc462e023a9faf046d57794184028123aa208"
+            ],
+            "index": "pypi",
+            "version": "==3.8.3"
         },
         "ipykernel": {
             "hashes": [
@@ -308,6 +316,13 @@
             "index": "pypi",
             "version": "==3.3.0"
         },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
         "mistune": {
             "hashes": [
                 "sha256:59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e",
@@ -333,11 +348,11 @@
         },
         "notebook": {
             "hashes": [
-                "sha256:42391d8f3b88676e774316527599e49c11f3a7e51c41035e9e44c1b58e1398d5",
-                "sha256:4cc4e44a43a83a7c2f5e85bfdbbfe1c68bed91b857741df9e593d213a6fc2d27"
+                "sha256:964cc40cff68e473f3778aef9266e867f7703cb4aebdfd250f334efe02f64c86",
+                "sha256:9990d51b9931a31e681635899aeb198b4c4b41586a9e87fbfaaed1a71d0a05b6"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==6.1.1"
+            "version": "==6.1.3"
         },
         "numpy": {
             "hashes": [
@@ -487,6 +502,22 @@
             "markers": "os_name != 'nt'",
             "version": "==0.6.0"
         },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367",
+                "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.6.0"
+        },
+        "pycodestyle-magic": {
+            "hashes": [
+                "sha256:0059288f6479c34b92bd33e8a15c57fd93721d9b4464af0511b7e6d1221f7108",
+                "sha256:b3765c2e26dc72a387d23277ea788be2db7b2393043fb723754c7cb924f8fefe"
+            ],
+            "index": "pypi",
+            "version": "==0.5"
+        },
         "pycparser": {
             "hashes": [
                 "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0",
@@ -494,6 +525,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.20"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92",
+                "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.2.0"
         },
         "pygments": {
             "hashes": [

--- a/notebooks/activity.ipynb
+++ b/notebooks/activity.ipynb
@@ -6,6 +6,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%load_ext pycodestyle_magic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pycodestyle_on"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from pathlib import Path\n",
     "\n",
     "from matplotlib.cm import get_cmap\n",
@@ -840,7 +858,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR adds [pycodestyle_magic](https://github.com/mattijn/pycodestyle_magic) and [flake8](https://flake8.pycqa.org/en/latest/) to the project to enable linting inside jupyter notebooks.

<img width="500" alt="Screenshot 2020-08-13 at 20 29 27" src="https://user-images.githubusercontent.com/12784650/90178371-bab42f80-dda3-11ea-8387-59302c4b1457.png">
