### PR TITLE
Use curl or wget to download data depending on which is available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,14 @@ DATA_DIR=data
 DATA_URI=https://archive.ics.uci.edu/ml/machine-learning-databases/00427/Datasets_Healthy_Older_People.zip
 DATA_DEST=raw
 
+DOWNLOAD:=$(shell [ `command -v curl` ] && echo curl || echo wget)
+
+ifeq ($(DOWNLOAD), curl)
+	DOWNLOAD_FLAG=-o
+else
+	DOWNLOAD_FLAG=-O
+endif
+
 # Initialise development enviromment
 init:
 	$(PIP) install pipenv --upgrade && \
@@ -12,7 +20,7 @@ init:
 # Download data
 data: FORCE
 	mkdir -p $(DATA_DIR)/$(DATA_DEST) && \
-	curl $(DATA_URI) --output $(DATA_DIR)/data.zip && \
+	$(DOWNLOAD) $(DATA_URI) $(DOWNLOAD_FLAG) $(DATA_DIR)/data.zip && \
 	unzip -ojqq $(DATA_DIR)/data.zip "S[12]_Dataset/d*" -d $(DATA_DIR)/$(DATA_DEST)
 
 FORCE:

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,11 @@ DATA_DIR=data
 DATA_URI=https://archive.ics.uci.edu/ml/machine-learning-databases/00427/Datasets_Healthy_Older_People.zip
 DATA_DEST=raw
 
+# := means evaluate, [] are a bit like if, so if curl isn't defined it's false and it will ignore echo curl and go to wget, || equivalent-ish to OR
+# so translates to 'if curl is installed, use it, else use wget'
 DOWNLOAD:=$(shell [ `command -v curl` ] && echo curl || echo wget)
 
+# curl and wget use different output flags..
 ifeq ($(DOWNLOAD), curl)
 	DOWNLOAD_FLAG=-o
 else


### PR DESCRIPTION
This PR enables the downloading of data to use `curl` or `wget` depending on which is available on the system.