### PR TITLE
Add jupyter notebook configuration to enable automatic path definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,7 +81,7 @@ target/
 # IPython
 profile_default/
 ipython_config.py
-.ipython
+.ipython/
 
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ target/
 # IPython
 profile_default/
 ipython_config.py
+.ipython
 
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is

--- a/jupyter_notebook_config.py
+++ b/jupyter_notebook_config.py
@@ -1,0 +1,15 @@
+import os
+
+project_root = os.path.abspath(os.path.dirname(__file__))
+data = os.path.join(project_root, 'data')
+
+ipython_dir = os.path.join(project_root, 'notebooks', '.ipython')
+os.environ['IPYTHONDIR'] = ipython_dir
+startup_dir = os.path.join(ipython_dir, 'profile_default', 'startup')
+os.makedirs(startup_dir, exist_ok=True)
+
+with open(os.path.join(startup_dir, '00-startup.py'), 'w') as file_out:
+    file_out.write(f'PROJECT_ROOT = "{project_root}"\n')
+    file_out.write(f'DATA_ROOT = "{data}"\n')
+
+c.NotebookApp.notebook_dir = './notebooks' # pylint: disable=undefined-variable

--- a/jupyter_notebook_config.py
+++ b/jupyter_notebook_config.py
@@ -1,7 +1,7 @@
 import os
 
 project_root = os.path.abspath(os.path.dirname(__file__))
-data = os.path.join(project_root, 'data')
+data_root = os.path.join(project_root, 'data')
 
 ipython_dir = os.path.join(project_root, 'notebooks', '.ipython')
 os.environ['IPYTHONDIR'] = ipython_dir
@@ -10,6 +10,6 @@ os.makedirs(startup_dir, exist_ok=True)
 
 with open(os.path.join(startup_dir, '00-startup.py'), 'w') as file_out:
     file_out.write(f'PROJECT_ROOT = "{project_root}"\n')
-    file_out.write(f'DATA_ROOT = "{data}"\n')
+    file_out.write(f'DATA_ROOT = "{data_root}"\n')
 
 c.NotebookApp.notebook_dir = './notebooks' # pylint: disable=undefined-variable


### PR DESCRIPTION
This PR adds a jupyter configuration file to the project which (provided `jupyter notebook` is run from the project root):

- automatically opens the browser in the `notebooks` directory
- defines constants such as `PROJECT_ROOT` and `DATA_ROOT` so that they are available automatically from the first cell without having to mess around with relative paths:
<img width="512" alt="Screenshot 2020-08-22 at 11 21 21" src="https://user-images.githubusercontent.com/12784650/90954157-e69d7800-e469-11ea-93d5-6aeedeb54461.png">

Note that in order for this to work, and maintain 'encapsulation' within the project, we have to force the ipython profile directory to be put into the `notebooks` directory, this directory `.ipython` has been added to `.gitignore`

It is hopefully useful, but I am open to discussion about how useful it actually may be in practice 😉